### PR TITLE
Refactor regexes, remove header and footer includes based on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Shoptet Bender 🤖
-
 ## Introduction
-Shoptet Bender proxies remote e-shop to localhost while injecting and serving your local `style.css` and `script.js`. This tool enables to development of visual changes without breaking the production e-shop. It is also suitable for Premium e-shop development, while emulation of the Blank mode is possible.
+Shoptet Bender proxies remote e-shop to localhost while injecting and serving your local JavaScripts and CSS styles. This tool enables the development of visual changes without breaking the production e-shop. It is also suitable for Premium e-shop development, while emulation of the Blank mode is possible.
 
 ## How it works
 
@@ -12,7 +11,7 @@ C(Local files) -- Static served files --> B
 ```
 
 ## Install
-Node >= 14 prerequisited\
+Node >= 18 prerequisited\
 Install global using yarn:\
 `yarn global add git+https://github.com/shoptet/shoptet-bender.git`
 
@@ -25,20 +24,36 @@ Install global using yarn:\
 ## Usage
 ### Step-by-step guide to start
 
-1. Create a folder for your files (css, js) that need to be injected to remote e-shop on localhost (let's say "my-project")
-2. Inside your project folder create another folder named "src"
-3. Create or move your "style.css" and "script.js" files into "src" folder
-4. Run --remote e-shop in console (let's say "shp-bender --remote https://classic.shoptet.cz/")
+1. 📁 If you want to use the prepared build step, create a following folder structure:
 
-And you're ready to go -> enjoy coding and development ;)
+```
+src/
+├── footer/
+│   ├── script1.js
+│   └── script2.js
+├── header/
+│   ├── markup.html
+│   └── style.css
+└── orderFinale/
+    └── remarketing.js
+```
+
+2. 📝 Create or move your script and styles to the corresponding folders
+3. 🖥️ Choose e-shop url, let's say Classic `shp-bender --remote https://classic.shoptet.cz/`
+
+And you're ready to go -> enjoy coding and development 🎉
 
 **OR**
 
 Try `shp-bender -h` for CLI help
 
-## Posible tool improvements
-Shoptet Bender is an open-source project, so your PRs are very welcomed. There are some suggestions for possible features, as Shoptet don't have the resources to develop this tool actively. So it is left as is for your active development. Some minor feature updates are possible.
-What could be done:
-- [ ] tools integration (Gulp, Grunt)
-- [ ] files concatenation
-- [ ] HEAD and BODY scripts location - this could better emulate admin fields
+**OR**
+
+🚀 Use our [Boilerplate wizard](https://github.com/shoptet/create-visual-addon-boilerplate) for even faster start. 🚀
+
+### Removing existing scripts and styles
+
+If you want to remove existing scripts and styles, you can use the `--removeHeaderIncludes` or `--removeFooterIncludes` flag followed by the string you want to remove. You can target for example number of the addon, or specific URL, project includes or comment in the script.
+
+## Possible tool improvements
+Shoptet Bender is an open-source project, and we’d love your help! Shoptet doesn’t have the resources to work on this tool continuously, so it’s a great chance for you to jump in and make it better. We’ve listed some feature ideas to get you started, but feel free to create your own. Even small updates can make a big difference, and your contributions are really valued!

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,8 @@ command
     .option('-r, --remote <url>', 'URL of the remote Eshop with https:// prefix')
     .option('-w, --watch', 'watch for changes and reload the page', true)
     .option('-b, --blankMode', 'simulate the blank template.', false)
-    .option('-n, --notify', 'display pop-over notifications in the browser', false);
+    .option('-n, --notify', 'display pop-over notifications in the browser', false)
+    .option('-rh, --removeHeaderIncludes [removeHeaderIncludes...]', 'remove header includes', false)
+    .option('-rf, --removeFooterIncludes [removeFooterIncludes...]', 'remove footer includes', false);
 
 export default command;

--- a/config.json
+++ b/config.json
@@ -1,8 +1,5 @@
 {
-    "defaultUrl": "https://363432.myshoptet.com",
+    "defaultUrl": "https://classic.shoptet.cz/",
     "sourceFolder": "./src",
-    "outputFolder": "./dist",
-    "removeFooterIncludes": [
-        "project"
-    ]
+    "outputFolder": "./dist"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,8 @@
 {
-    "defaultUrl": "https://classic.shoptet.cz/",
+    "defaultUrl": "https://363432.myshoptet.com",
     "sourceFolder": "./src",
-    "outputFolder": "./dist"
+    "outputFolder": "./dist",
+    "removeFooterIncludes": [
+        "project"
+    ]
 }


### PR DESCRIPTION
# Summary
This pull request includes several changes to the `index.js` file, primarily focusing on enhancing the handling of HTML includes and simplifying the configuration. The most important changes include adding new regex patterns for header and footer includes, implementing functions to remove specific includes.

# Test plan
- [ ] clone repo
- [ ] choose eshop where are some custom codes or addons
- [ ] add strings to `removeFooterIncludes` or `removeHeaderIncludes` to `config.json` - these scripts will be removed
- [ ] run `node index.js` to test it out